### PR TITLE
Bumps ember-cli-babel version to 6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "favico.js"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^6.6.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This fixes the following warning: 

> DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: ember-project -> ember-cli-favico -> ember-cli-babel